### PR TITLE
ET-3826 lower default api method limit

### DIFF
--- a/b2b/api_gateway/proxy/main.tf
+++ b/b2b/api_gateway/proxy/main.tf
@@ -129,7 +129,9 @@ resource "aws_api_gateway_method_settings" "tenant" {
 
   method_path = "*/*"
   settings {
-    logging_level = "INFO"
+    logging_level          = "INFO"
+    throttling_burst_limit = var.default_method_throttle_settings != null ? var.default_method_throttle_settings.burst_limit : var.usage_plan_throttle_settings.burst_limit * 3
+    throttling_rate_limit  = var.default_method_throttle_settings != null ? var.default_method_throttle_settings.rate_limit : var.usage_plan_throttle_settings.rate_limit * 3
   }
 
   depends_on = [

--- a/b2b/api_gateway/proxy/variables.tf
+++ b/b2b/api_gateway/proxy/variables.tf
@@ -80,6 +80,15 @@ variable "usage_plan_throttle_settings" {
   }
 }
 
+variable "default_method_throttle_settings" {
+  description = "API request burst and rate (rps) limit for all methods, including those that don't require an API key"
+  type = object({
+    burst_limit = number
+    rate_limit  = number
+  })
+  default = null
+}
+
 variable "tags" {
   description = "Map of tags for the deployment"
   type        = map(string)


### PR DESCRIPTION
What:
Set a default limit for all methods (including methods that don't require an api key) instead of using the default aws account limit.