### PR TITLE
Add rds permission to SessionManagerForUser policy

### DIFF
--- a/b2b/tooling/ssm_user_policy/main.tf
+++ b/b2b/tooling/ssm_user_policy/main.tf
@@ -38,6 +38,14 @@ data "aws_iam_policy_document" "user_port_forward_remote" {
   }
 
   statement {
+    sid = "DescribeRdsClusters"
+    actions = [
+      "rds:DescribeDBClusters"
+    ]
+    resources = ["arn:aws:rds:*:*:cluster:*"]
+  }
+
+  statement {
     sid = "TerminateSession"
     actions = [
       "ssm:TerminateSession",


### PR DESCRIPTION
Allow devs to access RDS cluster infos to be able to create a SSM connection