### PR TITLE
Use determanistic zip to create stable archives when uploading to lamnda

### DIFF
--- a/b2b/lambda/authentication/main.tf
+++ b/b2b/lambda/authentication/main.tf
@@ -38,12 +38,15 @@ module "role" {
   tags   = var.tags
 }
 
-data "archive_file" "source_code" {
-  type        = "zip"
-  source_file = local.filename
-  output_path = local.output_path
+### needs to have installed
+### https://github.com/timo-reymann/deterministic-zip
+### https://www.reddit.com/r/Terraform/comments/aupudn/building_deterministic_zips_to_minimize_lambda/
+data "external" "source_code" {
+  program = ["bash", "-c", "deterministic-zip -r ${local.output_path} ${local.filename} && echo '{ \"output\": \"${local.output_path}\" }'"]
 
-  depends_on = [local_sensitive_file.authentication_code]
+  depends_on = [
+    local_sensitive_file.authentication_code
+  ]
 }
 
 module "function" {
@@ -52,7 +55,7 @@ module "function" {
   function_name         = local.function_name
   handler               = "index-${var.tenant}.handler"
   runtime               = "nodejs16.x"
-  source_code_hash      = data.archive_file.source_code.output_base64sha256
+  source_code_hash      = filebase64sha256(data.external.source_code.result.output)
   output_path           = local.output_path
   lambda_role_arn       = module.role.arn
   log_retention_in_days = var.log_retention_in_days

--- a/b2b/lambda/authentication/terraform.tf
+++ b/b2b/lambda/authentication/terraform.tf
@@ -6,9 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "4.50.0"
     }
-    archive = {
-      source  = "hashicorp/archive"
-      version = "2.2.0"
+    external = {
+      source  = "hashicorp/external"
+      version = "2.2.3"
     }
     local = {
       source  = "hashicorp/local"

--- a/b2b/lambda/maintenance/terraform.tf
+++ b/b2b/lambda/maintenance/terraform.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "4.50.0"
     }
-    archive = {
-      source  = "hashicorp/archive"
-      version = "2.2.0"
-    }
     external = {
       source  = "hashicorp/external"
       version = "2.2.3"

--- a/embedding/lambda/authentication/terraform.tf
+++ b/embedding/lambda/authentication/terraform.tf
@@ -6,9 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "4.50.0"
     }
-    archive = {
-      source  = "hashicorp/archive"
-      version = "2.2.0"
+    external = {
+      source  = "hashicorp/external"
+      version = "2.2.3"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
This avoids resubmitting lambdas when nothing changed in the source code