### PR TITLE
ET-4167 adjust alarms

### DIFF
--- a/b2b/alarm/main.tf
+++ b/b2b/alarm/main.tf
@@ -1,0 +1,18 @@
+data "aws_caller_identity" "current" {}
+module "alarm" {
+  providers = {
+    aws = aws.monitoring-account
+  }
+  source = "../../generic/alarms/composite"
+
+  create_alarm = var.create_alarm
+  name         = "${data.aws_caller_identity.current.account_id}_b2b_system"
+  description  = "One or more incidents on the b2b system. Action required. Check dashboard for more insights."
+
+  rule = join(" OR ", [for arn in var.alarm_arns : "ALARM(${arn})"])
+
+  ok_actions    = var.ok_actions
+  alarm_actions = var.alarm_actions
+
+  tags = var.tags
+}

--- a/b2b/alarm/outputs.tf
+++ b/b2b/alarm/outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  description = "ARN of the CloudWatch alarm."
+  value       = module.alarm.arn
+}

--- a/b2b/alarm/terraform.tf
+++ b/b2b/alarm/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "1.3.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.50.0"
+    }
+  }
+}

--- a/b2b/alarm/variables.tf
+++ b/b2b/alarm/variables.tf
@@ -1,0 +1,29 @@
+variable "alarm_arns" {
+  description = "List of all alarm ARNs that are part of the composite alarm."
+  type        = list(string)
+  default     = []
+}
+
+variable "create_alarm" {
+  description = "Whether to create the alarm."
+  type        = bool
+  default     = true
+}
+
+variable "alarm_actions" {
+  description = "The set of actions to execute when this alarm transitions to the ALARM state from any other state."
+  type        = list(string)
+  default     = []
+}
+
+variable "ok_actions" {
+  description = " The set of actions to execute when this alarm transitions to an OK state from any other state."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "A map of labels to apply to contained resources."
+  type        = map(string)
+  default     = {}
+}

--- a/b2b/alb/main.tf
+++ b/b2b/alb/main.tf
@@ -92,9 +92,8 @@ module "alarms" {
 
   arn_suffix = aws_lb.this.arn_suffix
 
-  services_http_5xx_error = var.alarm_services_http_5xx_error
-  http_5xx_error          = var.alarm_http_5xx_error
-  http_4xx_error          = var.alarm_http_4xx_error
+  http_5xx_error = var.alarm_http_5xx_error
+  http_4xx_error = var.alarm_http_4xx_error
 
   tags = var.tags
 }

--- a/b2b/alb/variables.tf
+++ b/b2b/alb/variables.tf
@@ -43,12 +43,6 @@ variable "health_check_path" {
   default     = "/health"
 }
 
-variable "alarm_services_http_5xx_error" {
-  description = "Alarm for ALB services HTTP-5XX errors."
-  type        = any
-  default     = {}
-}
-
 variable "alarm_http_5xx_error" {
   description = "Alarm for ALB HTTP-5XX errors."
   type        = any

--- a/b2b/api_gateway/proxy/main.tf
+++ b/b2b/api_gateway/proxy/main.tf
@@ -228,6 +228,7 @@ module "alarms" {
 
   http_5xx_error = var.alarm_http_5xx_error
   latency        = var.alarm_latency
+  error_rate     = var.alarm_error_rate
 
   tags = var.tags
 }

--- a/b2b/api_gateway/proxy/main.tf
+++ b/b2b/api_gateway/proxy/main.tf
@@ -226,9 +226,8 @@ module "alarms" {
   api_name  = local.api_name
   api_stage = aws_api_gateway_stage.tenant.stage_name
 
-  http_5xx_error      = var.alarm_http_5xx_error
-  integration_latency = var.alarm_integration_latency
-  latency             = var.alarm_latency
+  http_5xx_error = var.alarm_http_5xx_error
+  latency        = var.alarm_latency
 
   tags = var.tags
 }

--- a/b2b/api_gateway/proxy/variables.tf
+++ b/b2b/api_gateway/proxy/variables.tf
@@ -102,7 +102,13 @@ variable "alarm_http_5xx_error" {
 }
 
 variable "alarm_latency" {
-  description = "Alarm for API Gateway average latency."
+  description = "Alarm for API Gateway p90 latency."
+  type        = any
+  default     = {}
+}
+
+variable "alarm_error_rate" {
+  description = "Alarm for an increased error rate on the API Gateway."
   type        = any
   default     = {}
 }

--- a/b2b/api_gateway/proxy/variables.tf
+++ b/b2b/api_gateway/proxy/variables.tf
@@ -101,12 +101,6 @@ variable "alarm_http_5xx_error" {
   default     = {}
 }
 
-variable "alarm_integration_latency" {
-  description = "Alarm for API Gateway average integration latency."
-  type        = any
-  default     = {}
-}
-
 variable "alarm_latency" {
   description = "Alarm for API Gateway average latency."
   type        = any

--- a/embedding/alarm/main.tf
+++ b/embedding/alarm/main.tf
@@ -1,0 +1,18 @@
+data "aws_caller_identity" "current" {}
+module "alarm" {
+  providers = {
+    aws = aws.monitoring-account
+  }
+  source = "../../generic/alarms/composite"
+
+  create_alarm = var.create_alarm
+  name         = "${data.aws_caller_identity.current.account_id}_nc_system"
+  description  = "One or more incidents on the NC system. Action required. Check dashboard for more insights."
+
+  rule = join(" OR ", [for arn in var.alarm_arns : "ALARM(${arn})"])
+
+  ok_actions    = var.ok_actions
+  alarm_actions = var.alarm_actions
+
+  tags = var.tags
+}

--- a/embedding/alarm/outputs.tf
+++ b/embedding/alarm/outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  description = "ARN of the CloudWatch alarm."
+  value       = module.alarm.arn
+}

--- a/embedding/alarm/terraform.tf
+++ b/embedding/alarm/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "1.3.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.50.0"
+    }
+  }
+}

--- a/embedding/alarm/variables.tf
+++ b/embedding/alarm/variables.tf
@@ -1,0 +1,29 @@
+variable "alarm_arns" {
+  description = "List of all alarm ARNs that are part of the composite alarm."
+  type        = list(string)
+  default     = []
+}
+
+variable "create_alarm" {
+  description = "Whether to create the alarm."
+  type        = bool
+  default     = true
+}
+
+variable "alarm_actions" {
+  description = "The set of actions to execute when this alarm transitions to the ALARM state from any other state."
+  type        = list(string)
+  default     = []
+}
+
+variable "ok_actions" {
+  description = " The set of actions to execute when this alarm transitions to an OK state from any other state."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "A map of labels to apply to contained resources."
+  type        = map(string)
+  default     = {}
+}

--- a/embedding/alb/main.tf
+++ b/embedding/alb/main.tf
@@ -92,9 +92,8 @@ module "alarms" {
 
   arn_suffix = aws_lb.this.arn_suffix
 
-  services_http_5xx_error = var.alarm_services_http_5xx_error
-  http_5xx_error          = var.alarm_http_5xx_error
-  http_4xx_error          = var.alarm_http_4xx_error
+  http_5xx_error = var.alarm_http_5xx_error
+  http_4xx_error = var.alarm_http_4xx_error
 
   tags = var.tags
 }

--- a/embedding/alb/variables.tf
+++ b/embedding/alb/variables.tf
@@ -43,12 +43,6 @@ variable "health_check_path" {
   default     = "/health"
 }
 
-variable "alarm_services_http_5xx_error" {
-  description = "Alarm for ALB services HTTP-5XX errors."
-  type        = any
-  default     = {}
-}
-
 variable "alarm_http_5xx_error" {
   description = "Alarm for ALB HTTP-5XX errors."
   type        = any

--- a/embedding/api_gateway/proxy.tf
+++ b/embedding/api_gateway/proxy.tf
@@ -196,6 +196,7 @@ module "alarms" {
 
   http_5xx_error = var.alarm_http_5xx_error
   latency        = var.alarm_latency
+  error_rate     = var.alarm_error_rate
 
   tags = var.tags
 }

--- a/embedding/api_gateway/proxy.tf
+++ b/embedding/api_gateway/proxy.tf
@@ -194,9 +194,8 @@ module "alarms" {
   api_name  = local.api_name
   api_stage = aws_api_gateway_stage.tenant.stage_name
 
-  http_5xx_error      = var.alarm_http_5xx_error
-  integration_latency = var.alarm_integration_latency
-  latency             = var.alarm_latency
+  http_5xx_error = var.alarm_http_5xx_error
+  latency        = var.alarm_latency
 
   tags = var.tags
 }

--- a/embedding/api_gateway/variables.tf
+++ b/embedding/api_gateway/variables.tf
@@ -102,7 +102,13 @@ variable "alarm_http_5xx_error" {
 }
 
 variable "alarm_latency" {
-  description = "Alarm for API Gateway average latency."
+  description = "Alarm for API Gateway p90 latency."
+  type        = any
+  default     = {}
+}
+
+variable "alarm_error_rate" {
+  description = "Alarm for an increased error rate on the API Gateway."
   type        = any
   default     = {}
 }

--- a/embedding/api_gateway/variables.tf
+++ b/embedding/api_gateway/variables.tf
@@ -101,12 +101,6 @@ variable "alarm_http_5xx_error" {
   default     = {}
 }
 
-variable "alarm_integration_latency" {
-  description = "Alarm for API Gateway average integration latency."
-  type        = any
-  default     = {}
-}
-
 variable "alarm_latency" {
   description = "Alarm for API Gateway average latency."
   type        = any

--- a/generic/alarms/alb/main.tf
+++ b/generic/alarms/alb/main.tf
@@ -7,45 +7,8 @@ locals {
     threshold       = 0
   }
 
-  services_http_5xx_error_conf = merge(local.defaults, var.services_http_5xx_error)
-  http_5xx_error_conf          = merge(local.defaults, var.http_5xx_error)
-  http_4xx_error_conf          = merge(local.defaults, var.http_4xx_error)
-}
-
-module "services_http_5xx_error" {
-  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "4.2.1"
-
-  create_metric_alarm = local.services_http_5xx_error_conf.create_alarm
-  alarm_name          = "${var.prefix}alb_services_5xx_error"
-  alarm_description   = "Number of ALB services HTTP-5XX errors > ${local.services_http_5xx_error_conf.threshold}. It may indicate an issue within the ECS services."
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  threshold           = local.services_http_5xx_error_conf.threshold
-  treat_missing_data  = "notBreaching"
-
-  metric_query = [{
-    id          = "m1"
-    account_id  = var.account_id
-    return_data = true
-
-    metric = [{
-      namespace   = "AWS/ApplicationELB"
-      metric_name = "HTTPCode_Target_5XX_Count"
-      period      = 60
-      stat        = "Sum"
-      dimensions = {
-        LoadBalancer = var.arn_suffix
-      }
-    }]
-    }
-  ]
-
-  actions_enabled = local.services_http_5xx_error_conf.actions_enabled
-  alarm_actions   = local.services_http_5xx_error_conf.alarm_actions
-  ok_actions      = local.services_http_5xx_error_conf.ok_actions
-
-  tags = var.tags
+  http_5xx_error_conf = merge(local.defaults, var.http_5xx_error)
+  http_4xx_error_conf = merge(local.defaults, var.http_4xx_error)
 }
 
 module "http_5xx_error" {

--- a/generic/alarms/alb/outputs.tf
+++ b/generic/alarms/alb/outputs.tf
@@ -1,8 +1,7 @@
 output "arns" {
   description = "ARNs of the CloudWatch alarms."
   value = {
-    services_http_5xx_error = try(module.services_http_5xx_error.cloudwatch_metric_alarm_arn, "")
-    http_5xx_error          = try(module.http_5xx_error.cloudwatch_metric_alarm_arn, "")
-    http_4xx_error          = try(module.http_4xx_error.cloudwatch_metric_alarm_arn, "")
+    http_5xx_error = try(module.http_5xx_error.cloudwatch_metric_alarm_arn, "")
+    http_4xx_error = try(module.http_4xx_error.cloudwatch_metric_alarm_arn, "")
   }
 }

--- a/generic/alarms/alb/variables.tf
+++ b/generic/alarms/alb/variables.tf
@@ -14,12 +14,6 @@ variable "prefix" {
   default     = ""
 }
 
-variable "services_http_5xx_error" {
-  description = "Alarm for ALB services HTTP-5XX errors."
-  type        = any
-  default     = {}
-}
-
 variable "http_5xx_error" {
   description = "Alarm for ALB HTTP-5XX errors."
   type        = any

--- a/generic/alarms/api_gateway/main.tf
+++ b/generic/alarms/api_gateway/main.tf
@@ -6,8 +6,9 @@ locals {
     alarm_actions   = []
   }
 
+  error_rate_conf     = merge(local.defaults, { threshold = 1 }, var.error_rate)
   http_5xx_error_conf = merge(local.defaults, { threshold = 0 }, var.http_5xx_error)
-  latency_conf        = merge(local.defaults, { threshold = 300 }, var.latency)
+  latency_conf        = merge(local.defaults, { threshold = 100 }, var.latency)
 }
 
 module "http_5xx_error" {
@@ -53,9 +54,9 @@ module "latency" {
 
   create_metric_alarm = local.latency_conf.create_alarm
   alarm_name          = "${var.prefix}${var.api_name}_api_gateway_latency"
-  alarm_description   = "High latency for ${var.api_name}. Average latency > ${local.latency_conf.threshold}ms"
+  alarm_description   = "High latency for ${var.api_name}. P90 latency > ${local.latency_conf.threshold}ms"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 2
+  evaluation_periods  = 5
   threshold           = local.latency_conf.threshold
   treat_missing_data  = "notBreaching"
 
@@ -68,7 +69,7 @@ module "latency" {
       namespace   = "AWS/ApiGateway"
       metric_name = "Latency"
       period      = 60
-      stat        = "Average"
+      stat        = "p90"
       dimensions = {
         ApiName = var.api_name
         Stage   = var.api_stage
@@ -80,6 +81,62 @@ module "latency" {
   actions_enabled = local.latency_conf.actions_enabled
   alarm_actions   = local.latency_conf.alarm_actions
   ok_actions      = local.latency_conf.ok_actions
+
+  tags = var.tags
+}
+
+module "error_rate" {
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
+  version = "4.2.1"
+
+  create_metric_alarm = local.error_rate_conf.create_alarm
+  alarm_name          = "${var.prefix}${var.api_name}_api_gateway_error_rate"
+  alarm_description   = "Error rate above ${local.error_rate_conf.threshold}% for ${var.api_name}."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  threshold           = local.error_rate_conf.threshold
+  treat_missing_data  = "notBreaching"
+
+  metric_query = [{
+    id          = "e1"
+    expression  = "100 * (m2 / m1)"
+    label       = "error_rate"
+    return_data = "true"
+    }, {
+    id         = "m1"
+    account_id = var.account_id
+
+    metric = [{
+      namespace   = "AWS/ApiGateway"
+      metric_name = "Count"
+      period      = 60
+      stat        = "Sum"
+
+      dimensions = {
+        ApiName = var.api_name
+        Stage   = var.api_stage
+      }
+    }]
+    }, {
+    id         = "m2"
+    account_id = var.account_id
+
+    metric = [{
+      namespace   = "AWS/ApiGateway"
+      metric_name = "5XXError"
+      period      = 60
+      stat        = "Sum"
+
+      dimensions = {
+        ApiName = var.api_name
+        Stage   = var.api_stage
+      }
+    }]
+  }]
+
+  actions_enabled = local.error_rate_conf.actions_enabled
+  alarm_actions   = local.error_rate_conf.alarm_actions
+  ok_actions      = local.error_rate_conf.ok_actions
 
   tags = var.tags
 }

--- a/generic/alarms/api_gateway/main.tf
+++ b/generic/alarms/api_gateway/main.tf
@@ -6,9 +6,8 @@ locals {
     alarm_actions   = []
   }
 
-  http_5xx_error_conf      = merge(local.defaults, { threshold = 0 }, var.http_5xx_error)
-  integration_latency_conf = merge(local.defaults, { threshold = 250 }, var.integration_latency)
-  latency_conf             = merge(local.defaults, { threshold = 300 }, var.latency)
+  http_5xx_error_conf = merge(local.defaults, { threshold = 0 }, var.http_5xx_error)
+  latency_conf        = merge(local.defaults, { threshold = 300 }, var.latency)
 }
 
 module "http_5xx_error" {
@@ -44,43 +43,6 @@ module "http_5xx_error" {
   actions_enabled = local.http_5xx_error_conf.actions_enabled
   alarm_actions   = local.http_5xx_error_conf.alarm_actions
   ok_actions      = local.http_5xx_error_conf.ok_actions
-
-  tags = var.tags
-}
-
-module "integration_latency" {
-  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "4.2.1"
-
-  create_metric_alarm = local.integration_latency_conf.create_alarm
-  alarm_name          = "${var.prefix}${var.api_name}_api_gateway_integration_latency"
-  alarm_description   = "High integration latency for ${var.api_name}. Average integration latency > ${local.integration_latency_conf.threshold}ms"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 2
-  threshold           = local.integration_latency_conf.threshold
-  treat_missing_data  = "notBreaching"
-
-  metric_query = [{
-    id          = "m1"
-    account_id  = var.account_id
-    return_data = true
-
-    metric = [{
-      namespace   = "AWS/ApiGateway"
-      metric_name = "IntegrationLatency"
-      period      = 60
-      stat        = "Average"
-      dimensions = {
-        ApiName = var.api_name
-        Stage   = var.api_stage
-      }
-    }]
-    }
-  ]
-
-  actions_enabled = local.integration_latency_conf.actions_enabled
-  alarm_actions   = local.integration_latency_conf.alarm_actions
-  ok_actions      = local.integration_latency_conf.ok_actions
 
   tags = var.tags
 }

--- a/generic/alarms/api_gateway/main.tf
+++ b/generic/alarms/api_gateway/main.tf
@@ -56,7 +56,7 @@ module "latency" {
   alarm_name          = "${var.prefix}${var.api_name}_api_gateway_latency"
   alarm_description   = "High latency for ${var.api_name}. P90 latency > ${local.latency_conf.threshold}ms"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 5
+  evaluation_periods  = 10
   threshold           = local.latency_conf.threshold
   treat_missing_data  = "notBreaching"
 

--- a/generic/alarms/api_gateway/outputs.tf
+++ b/generic/alarms/api_gateway/outputs.tf
@@ -3,5 +3,6 @@ output "arns" {
   value = {
     http_5xx_error = try(module.http_5xx_error.cloudwatch_metric_alarm_arn, "")
     latency        = try(module.latency.cloudwatch_metric_alarm_arn, "")
+    error_rate     = try(module.error_rate.cloudwatch_metric_alarm_arn, "")
   }
 }

--- a/generic/alarms/api_gateway/outputs.tf
+++ b/generic/alarms/api_gateway/outputs.tf
@@ -1,8 +1,7 @@
 output "arns" {
   description = "ARNs of the CloudWatch alarms."
   value = {
-    http_5xx_error      = try(module.http_5xx_error.cloudwatch_metric_alarm_arn, "")
-    integration_latency = try(module.integration_latency.cloudwatch_metric_alarm_arn, "")
-    latency             = try(module.latency.cloudwatch_metric_alarm_arn, "")
+    http_5xx_error = try(module.http_5xx_error.cloudwatch_metric_alarm_arn, "")
+    latency        = try(module.latency.cloudwatch_metric_alarm_arn, "")
   }
 }

--- a/generic/alarms/api_gateway/variables.tf
+++ b/generic/alarms/api_gateway/variables.tf
@@ -27,7 +27,13 @@ variable "http_5xx_error" {
 }
 
 variable "latency" {
-  description = "Alarm for API Gateway average latency."
+  description = "Alarm for API Gateway p90 latency."
+  type        = any
+  default     = {}
+}
+
+variable "error_rate" {
+  description = "Alarm for an increased error rate on the API Gateway."
   type        = any
   default     = {}
 }

--- a/generic/alarms/api_gateway/variables.tf
+++ b/generic/alarms/api_gateway/variables.tf
@@ -26,12 +26,6 @@ variable "http_5xx_error" {
   default     = {}
 }
 
-variable "integration_latency" {
-  description = "Alarm for API Gateway average integration latency."
-  type        = any
-  default     = {}
-}
-
 variable "latency" {
   description = "Alarm for API Gateway average latency."
   type        = any

--- a/generic/alarms/aurora/main.tf
+++ b/generic/alarms/aurora/main.tf
@@ -19,7 +19,7 @@ module "read_latency" {
   alarm_name          = "${var.prefix}aurora_read_latency"
   alarm_description   = "High average Aurora read latency > ${local.read_latency_conf.threshold}ms. It may indicate slow queries."
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
+  evaluation_periods  = 5
   threshold           = local.read_latency_conf.threshold
 
   metric_query = [{
@@ -58,7 +58,7 @@ module "write_latency" {
   alarm_name          = "${var.prefix}aurora_write_latency"
   alarm_description   = "High average Aurora write latency > ${local.write_latency_conf.threshold}ms. It may indicate slow queries."
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
+  evaluation_periods  = 5
   threshold           = local.write_latency_conf.threshold
 
   metric_query = [{

--- a/generic/alarms/composite/main.tf
+++ b/generic/alarms/composite/main.tf
@@ -1,0 +1,13 @@
+resource "aws_cloudwatch_composite_alarm" "this" {
+  count = var.create_alarm ? 1 : 0
+
+  alarm_description = var.description
+  alarm_name        = var.name
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  alarm_rule = var.rule
+
+  tags = var.tags
+}

--- a/generic/alarms/composite/outputs.tf
+++ b/generic/alarms/composite/outputs.tf
@@ -1,0 +1,4 @@
+output "arns" {
+  description = "ARN of the CloudWatch alarm."
+  value       = try(aws_cloudwatch_composite_alarm.this.arn, "")
+}

--- a/generic/alarms/composite/outputs.tf
+++ b/generic/alarms/composite/outputs.tf
@@ -1,4 +1,4 @@
-output "arns" {
+output "arn" {
   description = "ARN of the CloudWatch alarm."
-  value       = try(aws_cloudwatch_composite_alarm.this.arn, "")
+  value       = try(aws_cloudwatch_composite_alarm.this[0].arn, "")
 }

--- a/generic/alarms/composite/terraform.tf
+++ b/generic/alarms/composite/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "1.3.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.50.0"
+    }
+  }
+}

--- a/generic/alarms/composite/variables.tf
+++ b/generic/alarms/composite/variables.tf
@@ -1,0 +1,38 @@
+variable "name" {
+  description = "The name for the composite alarm. This name must be unique within the region."
+  type        = string
+}
+
+variable "description" {
+  description = "The description for the composite alarm."
+  type        = string
+}
+
+variable "rule" {
+  description = "An expression that specifies which other alarms are to be evaluated to determine this composite alarm's state."
+  type        = string
+}
+
+variable "create_alarm" {
+  description = "Whether to create the alarm."
+  type        = bool
+  default     = true
+}
+
+variable "alarm_actions" {
+  description = "The set of actions to execute when this alarm transitions to the ALARM state from any other state."
+  type        = list(string)
+  default     = []
+}
+
+variable "ok_actions" {
+  description = " The set of actions to execute when this alarm transitions to an OK state from any other state."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "A map of labels to apply to contained resources."
+  type        = map(string)
+  default     = {}
+}

--- a/generic/alarms/ecs_service/main.tf
+++ b/generic/alarms/ecs_service/main.tf
@@ -22,7 +22,7 @@ module "cpu_usage" {
   alarm_name          = "${var.prefix}${var.service_name}_cpu_usage"
   alarm_description   = "High CPU usage for ${var.service_name}. It may indicate that the auto scaling reach its maximum."
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 3
+  evaluation_periods  = 2
   threshold           = local.cpu_usage_conf.threshold
 
   metric_query = [{

--- a/generic/alarms/waf/main.tf
+++ b/generic/alarms/waf/main.tf
@@ -6,47 +6,8 @@ locals {
     alarm_actions   = []
   }
 
-  all_requests_conf         = merge(local.defaults, { threshold = 40000 }, var.all_requests)
   all_requests_blocked_conf = merge(local.defaults, { threshold = 5000 }, var.all_requests_blocked)
   ip_rate_limit_conf        = merge(local.defaults, { threshold = 0 }, var.ip_rate_limit)
-}
-
-module "all_requests" {
-  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "4.2.1"
-
-  create_metric_alarm = local.all_requests_conf.create_alarm
-  alarm_name          = "${var.prefix}waf_all_requests"
-  alarm_description   = "High traffic load on ${var.web_acl_region} ${var.web_acl_name}. Number of WAF ALL requests > ${local.all_requests_conf.threshold}."
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 2
-  threshold           = local.all_requests_conf.threshold
-  treat_missing_data  = "notBreaching"
-
-  metric_query = [{
-    id          = "m1"
-    account_id  = var.account_id
-    return_data = true
-
-    metric = [{
-      namespace   = "AWS/WAFV2"
-      metric_name = "CountedRequests"
-      period      = 60
-      stat        = "Sum"
-      dimensions = {
-        WebACL = var.web_acl_name
-        Region = var.web_acl_region
-        Rule   = "ALL"
-      }
-    }]
-    }
-  ]
-
-  actions_enabled = local.all_requests_conf.actions_enabled
-  alarm_actions   = local.all_requests_conf.alarm_actions
-  ok_actions      = local.all_requests_conf.ok_actions
-
-  tags = var.tags
 }
 
 module "all_requests_blocked" {

--- a/generic/alarms/waf/outputs.tf
+++ b/generic/alarms/waf/outputs.tf
@@ -1,7 +1,6 @@
 output "arns" {
   description = "ARNs of the CloudWatch alarms."
   value = {
-    all_requests         = try(module.all_requests.cloudwatch_metric_alarm_arn, "")
     all_requests_blocked = try(module.all_requests_blocked.cloudwatch_metric_alarm_arn, "")
     ip_rate_limit        = try(module.ip_rate_limit.cloudwatch_metric_alarm_arn, "")
   }

--- a/generic/alarms/waf/variables.tf
+++ b/generic/alarms/waf/variables.tf
@@ -19,12 +19,6 @@ variable "prefix" {
   default     = ""
 }
 
-variable "all_requests" {
-  description = "Alarm for WAF ALL requests."
-  type        = any
-  default     = {}
-}
-
 variable "all_requests_blocked" {
   description = "Alarm for WAF ALL blocked requests."
   type        = any

--- a/generic/waf/main.tf
+++ b/generic/waf/main.tf
@@ -217,7 +217,6 @@ module "alarms" {
   web_acl_name   = aws_wafv2_web_acl.api_gateway.name
   web_acl_region = data.aws_region.current.name
 
-  all_requests         = var.alarm_all_requests
   all_requests_blocked = var.alarm_all_requests_blocked
   ip_rate_limit        = var.alarm_ip_rate_limit
 

--- a/generic/waf/variables.tf
+++ b/generic/waf/variables.tf
@@ -36,12 +36,6 @@ variable "path_rules" {
   description = "A list of path entry objects, that describe which paths are allowed by the firewall, an empty array would block all requests."
 }
 
-variable "alarm_all_requests" {
-  description = "Alarm for WAF ALL requests."
-  type        = any
-  default     = {}
-}
-
 variable "alarm_all_requests_blocked" {
   description = "Alarm for WAF ALL blocked requests."
   type        = any


### PR DESCRIPTION
Alarms that have been removed
- WAF ALL request
- ALB service HTTP 5XX error
- API Gateway Integration Latency

Alarms that have been added 
- error rate of an API Gateway > 1% within 1min
- latency p90 of an API Gateway > 100ms within 10min
- composite alarms for b2b and embedding