### PR TITLE
ET-4050 make timezone configurable

### DIFF
--- a/b2b/service/users/variables.tf
+++ b/b2b/service/users/variables.tf
@@ -144,10 +144,11 @@ variable "max_count" {
 }
 
 variable "scheduled_scaling" {
-  description = "A list of schedule configurations in order to scale the service out and in. Timezone is UTC."
+  description = "A list of schedule configurations in order to scale the service out and in."
   type = list(object({
     schedule_out = string
     schedule_in  = string
+    timezone     = string
     min_out      = number
     max_out      = number
   }))

--- a/generic/service/asg/main.tf
+++ b/generic/service/asg/main.tf
@@ -52,6 +52,7 @@ resource "aws_appautoscaling_scheduled_action" "scheduled_out" {
   resource_id        = aws_appautoscaling_target.service_with_scheduled[0].resource_id
   scalable_dimension = aws_appautoscaling_target.service_with_scheduled[0].scalable_dimension
   schedule           = "cron(${var.scheduled_scaling[count.index].schedule_out})"
+  timezone           = var.scheduled_scaling[count.index].timezone
 
   scalable_target_action {
     min_capacity = var.scheduled_scaling[count.index].min_out
@@ -69,6 +70,7 @@ resource "aws_appautoscaling_scheduled_action" "scheduled_in" {
   resource_id        = aws_appautoscaling_target.service_with_scheduled[0].resource_id
   scalable_dimension = aws_appautoscaling_target.service_with_scheduled[0].scalable_dimension
   schedule           = "cron(${var.scheduled_scaling[count.index].schedule_in})"
+  timezone           = var.scheduled_scaling[count.index].timezone
 
   scalable_target_action {
     min_capacity = var.min_tasks

--- a/generic/service/asg/variables.tf
+++ b/generic/service/asg/variables.tf
@@ -45,10 +45,11 @@ variable "scale_out_cooldown" {
 }
 
 variable "scheduled_scaling" {
-  description = "A list of schedule configurations in order to scale the service out and in. Timezone is UTC."
+  description = "A list of schedule configurations in order to scale the service out and in."
   type = list(object({
     schedule_out = string
     schedule_in  = string
+    timezone     = string
     min_out      = number
     max_out      = number
   }))


### PR DESCRIPTION
small addition to make the timezone configurable. default is UTC. however aws respects the Daylight Saving Time if the timezone observes DST
https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-scheduled-scaling.html#sch-actions_rules