### PR TITLE
Add token_size as paramater, so we can override it

### DIFF
--- a/b2b/service/documents/main.tf
+++ b/b2b/service/documents/main.tf
@@ -96,6 +96,7 @@ module "service" {
     XAYN_WEB_API__NET__KEEP_ALIVE                     = var.keep_alive
     XAYN_WEB_API__NET__CLIENT_REQUEST_TIMEOUT         = var.request_timeout
     XAYN_WEB_API__LOGGING__LEVEL                      = var.logging_level
+    XAYN_WEB_API__EMBEDDING__TOKEN_SIZE               = var.token_size
   }
   secrets = {
     XAYN_WEB_API__STORAGE__ELASTIC__PASSWORD  = var.elasticsearch_password_ssm_parameter_arn

--- a/b2b/service/documents/variables.tf
+++ b/b2b/service/documents/variables.tf
@@ -167,6 +167,12 @@ variable "alarm_log_error" {
   default     = {}
 }
 
+variable "token_size" {
+  description = "The size of the token for the embeddings"
+  type        = string
+  default     = "250"
+}
+
 variable "tags" {
   description = "Custom tags to set on the underlining resources"
   type        = map(string)

--- a/b2b/service/users/main.tf
+++ b/b2b/service/users/main.tf
@@ -105,6 +105,7 @@ module "service" {
     XAYN_WEB_API__NET__KEEP_ALIVE                           = var.keep_alive
     XAYN_WEB_API__NET__CLIENT_REQUEST_TIMEOUT               = var.request_timeout
     XAYN_WEB_API__LOGGING__LEVEL                            = var.logging_level
+    XAYN_WEB_API__EMBEDDING__TOKEN_SIZE                     = var.token_size
   }
   secrets = {
     XAYN_WEB_API__STORAGE__ELASTIC__PASSWORD  = var.elasticsearch_password_ssm_parameter_arn

--- a/b2b/service/users/variables.tf
+++ b/b2b/service/users/variables.tf
@@ -185,6 +185,12 @@ variable "alarm_log_error" {
   default     = {}
 }
 
+variable "token_size" {
+  description = "The size of the token for the embeddings"
+  type        = string
+  default     = "250"
+}
+
 variable "tags" {
   description = "Custom tags to set on the underlining resources"
   type        = map(string)


### PR DESCRIPTION
the default in the engine is 250, so we set this here as well