### PR TITLE
fix redeployment

### DIFF
--- a/saas/api_gateway_proxy/main.tf
+++ b/saas/api_gateway_proxy/main.tf
@@ -236,7 +236,8 @@ resource "aws_api_gateway_deployment" "api" {
       aws_api_gateway_integration.options_cors_documents.id,
       aws_api_gateway_method.options_cors_documents_proxy.id,
       aws_api_gateway_integration.options_cors_documents_proxy.id,
-      data.aws_iam_policy_document._silo_management.json
+      data.aws_iam_policy_document._silo_management.json,
+      aws_api_gateway_rest_api_policy._silo_management.id
     ]))
   }
 


### PR DESCRIPTION
we need to add the id of the resource policy resource as well otherwise terraform does not wait for the api policy update and might redeploy the api with an old resource policy