### PR TITLE
Revert "ml config (#147)"

### DIFF
--- a/generic/elastic/cloud/main.tf
+++ b/generic/elastic/cloud/main.tf
@@ -40,18 +40,10 @@ resource "ec_deployment" "es_cluster" {
         max_size = "${var.hot_tier_memory_max}g"
       }
 
-      zone_count = var.hot_tier_zone_count
+      zone_count = var.zone_count
     }
-
     topology {
-      id   = "ml"
-      size = "${var.ml_tier_memory}g"
-
-      autoscaling {
-        max_size = "${var.ml_tier_memory_max}g"
-      }
-
-      zone_count = var.ml_tier_zone_count
+      id = "ml"
     }
 
     topology {
@@ -61,8 +53,7 @@ resource "ec_deployment" "es_cluster" {
 
   lifecycle {
     ignore_changes = [
-      elasticsearch[0].topology[2].size,
-      elasticsearch[0].topology[3].size
+      elasticsearch[0].topology[2].size
     ]
   }
 

--- a/generic/elastic/cloud/variables.tf
+++ b/generic/elastic/cloud/variables.tf
@@ -27,13 +27,13 @@ variable "hot_tier_memory_max" {
   default     = 15
 }
 
-variable "hot_tier_zone_count" {
+variable "zone_count" {
   description = "Specifies the number of zones for this deployment. (Valid 1, 2, 3)"
   type        = number
   default     = 2
 
   validation {
-    condition     = var.hot_tier_zone_count > 0 && var.hot_tier_zone_count < 4
+    condition     = var.zone_count > 0 && var.zone_count < 4
     error_message = "Valid values are 1, 2, 3"
   }
 }
@@ -42,29 +42,6 @@ variable "hot_tier_memory" {
   description = "Specifies the initial memory size (GB) of the elastic deployment"
   type        = number
   default     = 1
-}
-
-variable "ml_tier_memory" {
-  description = "Specifies the initial memory size (GB) of the elastic deployment"
-  type        = number
-  default     = 0
-}
-
-variable "ml_tier_memory_max" {
-  description = "Specifies maximum value of the memory resources (GB) for elastic to auto-scale"
-  type        = number
-  default     = 1
-}
-
-variable "ml_tier_zone_count" {
-  description = "Specifies the number of zones for this deployment. (Valid 1, 2, 3)"
-  type        = number
-  default     = 1
-
-  validation {
-    condition     = var.ml_tier_zone_count > 0 && var.ml_tier_zone_count < 4
-    error_message = "Valid values are 1 - 3"
-  }
 }
 
 variable "vpce_id" {


### PR DESCRIPTION
This reverts commit 0cdb7e7974d072de481730aac6a27ef9280035f2.

Elastic search auto scales the ml nodes once the pipeline has been deleted. there is no need to set this number of ml nodes to zero. I would like to revert this pr to avoid the renaming of the currently used variables (`hot_tier_zone_count`)