### PR TITLE
ET-6505: Aurora defaults update

### DIFF
--- a/b2b/aurora/main.tf
+++ b/b2b/aurora/main.tf
@@ -91,6 +91,9 @@ resource "aws_rds_cluster_instance" "this" {
   performance_insights_enabled = true
   monitoring_interval          = var.monitoring_interval
   monitoring_role_arn          = aws_iam_role.rds_enhanced_monitoring.arn
+
+  # The default latest CA
+  ca_cert_identifier           = "rds-ca-rsa2048-g1"
   tags                         = var.tags
 }
 

--- a/b2b/aurora/main.tf
+++ b/b2b/aurora/main.tf
@@ -93,8 +93,8 @@ resource "aws_rds_cluster_instance" "this" {
   monitoring_role_arn          = aws_iam_role.rds_enhanced_monitoring.arn
 
   # The default latest CA
-  ca_cert_identifier           = "rds-ca-rsa2048-g1"
-  tags                         = var.tags
+  ca_cert_identifier = "rds-ca-rsa2048-g1"
+  tags               = var.tags
 }
 
 resource "aws_db_subnet_group" "db_subnet_group" {

--- a/b2b/aurora/variables.tf
+++ b/b2b/aurora/variables.tf
@@ -48,7 +48,7 @@ variable "instance_class" {
 variable "engine_version" {
   description = "The version of the db engine"
   type        = string
-  default     = "14.5"
+  default     = "14.9"
 }
 
 variable "backup_retention_period" {


### PR DESCRIPTION
Two changes:
1. The engine version. It is apparently already updated on the AWS side, but we didn't adjust our terraform earlier.
2. The CA, I set it to the default recommended value. I don't think we'll ever need a custom value here, so I didn't put it into variables. Variables are for the things that we potentially may want to customize, this is meant to be fixed.